### PR TITLE
Fix/#81: 댓글 작성 모달 form 태그의 bg color 제거

### DIFF
--- a/src/components/Questions/PostCommentModal.tsx
+++ b/src/components/Questions/PostCommentModal.tsx
@@ -20,10 +20,7 @@ const PostCommentModal = forwardRef<HTMLInputElement, PostCommentModalProps>(
 
     return (
       <Modal aria-label="댓글 작성 모달" className="relative" onClose={onClose} {...props}>
-        <form
-          className="font-18 flex flex-col gap-24 bg-white p-24 font-semibold"
-          onSubmit={onPostComment}
-        >
+        <form className="font-18 flex flex-col gap-24 p-24 font-semibold" onSubmit={onPostComment}>
           <div className="flex flex-col gap-8">
             <label htmlFor="nickname_post">닉네임</label>
             <input


### PR DESCRIPTION
## 작업 내용
- 댓글 작성 모달의 border-radius가 적용 안되는 것 처럼 보였는데 모달 안의 form 태그에 background-color가 적용되어 있었음.
- form 태그의 background-color를 제거

closes: #81
## 주의 사항
