### PR TITLE
Refactor/#89: My 페이지 리팩토링

### DIFF
--- a/src/components/My/CategoriesSection.tsx
+++ b/src/components/My/CategoriesSection.tsx
@@ -1,0 +1,36 @@
+import { DISPLAYED_CATEGORIES } from '@/constants/categories';
+import type { DisplayedCategory } from '@/constants/categories';
+
+type CategoriesProps = {
+  selectedCategory: DisplayedCategory;
+  setSelectedCategory: React.Dispatch<React.SetStateAction<DisplayedCategory>>;
+};
+
+export default function CategoriesSection({
+  selectedCategory,
+  setSelectedCategory,
+}: CategoriesProps) {
+  const handleClickCategory = (category: DisplayedCategory) => setSelectedCategory(category);
+
+  return (
+    <section aria-labelledby="category" className="pb-38 pt-30">
+      <h2 id="category" className="a11y-hidden">
+        카테고리
+      </h2>
+      <div className="flex flex-wrap gap-8">
+        {DISPLAYED_CATEGORIES.map((category) => (
+          <button
+            key={category}
+            type="button"
+            className={`font-14 rounded-[1rem] px-18 py-10 font-semibold ${
+              category === selectedCategory ? 'bg-cyan text-dark' : 'bg-primary text-tertiary'
+            }`}
+            onClick={() => handleClickCategory(category)}
+          >
+            {category}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/My/ConfirmDeleteModal.tsx
+++ b/src/components/My/ConfirmDeleteModal.tsx
@@ -11,7 +11,7 @@ export default function ConfirmDeleteModal({
   ...props
 }: ConfirmDeleteModalProps) {
   return (
-    <Modal className="relative" onClose={onClose} {...props}>
+    <Modal aria-label="저장된 질문 삭제 확인 모달" className="p-40" onClose={onClose} {...props}>
       <form
         className="font-18 flex w-full flex-col gap-36 bg-white font-semibold"
         onSubmit={onDelete}

--- a/src/components/My/DeleteButton.tsx
+++ b/src/components/My/DeleteButton.tsx
@@ -1,0 +1,20 @@
+import Button from '@/components/common/Button';
+
+type DeleteButtonProps = {
+  selectedIds: number[];
+  onClick: () => void;
+};
+
+export default function DeleteButton({ selectedIds, onClick }: DeleteButtonProps) {
+  return (
+    <>
+      <Button
+        className="font-18 w-full max-w-[calc(var(--max-width)-2*var(--padding))] py-[1.9rem] font-semibold"
+        disabled={selectedIds.length === 0}
+        onClick={onClick}
+      >
+        {selectedIds.length === 0 ? '삭제하기' : `${selectedIds.length}개의 질문 삭제하기`}
+      </Button>
+    </>
+  );
+}

--- a/src/components/My/SavedQuestionsSection.tsx
+++ b/src/components/My/SavedQuestionsSection.tsx
@@ -1,0 +1,74 @@
+import QuestionItem from '@/components/My/QuestionItem';
+import { categoryKeys, CategoryKeys, DISPLAYED_CATEGORIES } from '@/constants/categories';
+import type { DisplayedCategory } from '@/constants/categories';
+import { ReactComponent as Blue } from '@/assets/images/blue.svg';
+import { SavedQuestionType } from '@/types/questions';
+
+const DISPLAYED_CATEGORY_MAP = {
+  ALL: 'all',
+  ...Object.fromEntries(
+    DISPLAYED_CATEGORIES.slice(1).map((category, index) => [category, categoryKeys[index]]),
+  ),
+} as Record<DisplayedCategory, 'all' | CategoryKeys>;
+
+type SavedQuestionsSectionProps = {
+  questions: SavedQuestionType[];
+  selectedCategory: DisplayedCategory;
+  selectedIds: number[];
+  setSelectedIds: React.Dispatch<React.SetStateAction<number[]>>;
+};
+
+export default function SavedQuestionsSection({
+  questions,
+  selectedCategory,
+  selectedIds,
+  setSelectedIds,
+}: SavedQuestionsSectionProps) {
+  const filteredQuestions =
+    selectedCategory === 'ALL'
+      ? questions
+      : questions.filter(
+          (question) => question.category === DISPLAYED_CATEGORY_MAP[selectedCategory],
+        );
+
+  const handleToggleCheckbox = (questionId: number) => {
+    setSelectedIds((prev) => {
+      if (prev.includes(questionId)) {
+        return prev.filter((value) => value !== questionId);
+      }
+      return [...prev, questionId];
+    });
+  };
+
+  return (
+    <section aria-labelledby="list">
+      <h2 id="list" className="a11y-hidden">
+        저장한 질문 리스트
+      </h2>
+
+      {filteredQuestions.length > 0 && (
+        <div className="font-14 mb-10 font-semibold text-white">
+          {filteredQuestions.length}개의 질문
+        </div>
+      )}
+
+      {filteredQuestions.length === 0 ? (
+        <div className="mt-112 flex flex-col items-center">
+          <Blue aria-hidden={true} />
+          <div className="font-18 mt-10 font-normal text-tertiary">아직 저장한 질문이 없어요!</div>
+        </div>
+      ) : (
+        <ul className="flex h-full flex-col gap-8">
+          {filteredQuestions.map((question) => (
+            <QuestionItem
+              key={question.id}
+              question={question}
+              handleCheck={() => handleToggleCheckbox(question.id)}
+              isChecked={selectedIds.includes(question.id)}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -4,8 +4,8 @@ import { useFocusTrap } from '@/hooks/useFocusTrap';
 import { ReactComponent as Close } from '@/assets/icons/close.svg';
 
 export type ModalProps = {
-  isOpen?: boolean;
-  onClose?: () => void;
+  isOpen: boolean;
+  onClose: () => void;
 } & React.HTMLAttributes<HTMLDialogElement>;
 
 export default function Modal({

--- a/src/constants/categories.tsx
+++ b/src/constants/categories.tsx
@@ -39,3 +39,7 @@ export const CATEGORIES: Record<
     img: <Usermade />,
   },
 };
+
+export const DISPLAYED_CATEGORIES = ['ALL', '셀프', '커플', '우정', '랜덤', '같이해요'] as const;
+
+export type DisplayedCategory = (typeof DISPLAYED_CATEGORIES)[number];

--- a/src/hooks/useConfirmDeleteQuestionsModal.tsx
+++ b/src/hooks/useConfirmDeleteQuestionsModal.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+import ConfirmDeleteModal from '@/components/My/ConfirmDeleteModal';
+import { SavedQuestionType } from '@/types/questions';
+
+type useConfirmDeleteQuestionsModalProps = {
+  selectedIds: number[];
+  setSelectedIds: React.Dispatch<React.SetStateAction<number[]>>;
+  setQuestions: React.Dispatch<React.SetStateAction<SavedQuestionType[]>>;
+};
+
+export default function useConfirmDeleteQuestionsModal({
+  selectedIds,
+  setSelectedIds,
+  setQuestions,
+}: useConfirmDeleteQuestionsModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleDelete = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setQuestions((prev) => prev.filter((question) => !selectedIds.includes(question.id)));
+    setSelectedIds([]);
+    handleClose();
+  };
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const renderConfirmDeleteQuestionsModal = () => (
+    <ConfirmDeleteModal isOpen={isOpen} onDelete={handleDelete} onClose={handleClose} />
+  );
+
+  return [renderConfirmDeleteQuestionsModal, handleOpen, handleClose];
+}

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -1,131 +1,43 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import Navbar from '@/components/common/Navbar';
-import Button from '@/components/common/Button';
-import ConfirmDeleteModal from '@/components/My/ConfirmDeleteModal';
-import QuestionItem from '@/components/My/QuestionItem';
+import CategoriesSection from '@/components/My/CategoriesSection';
+import SavedQuestionsSection from '@/components/My/SavedQuestionsSection';
+import type { DisplayedCategory } from '@/constants/categories';
+import DeleteButton from '@/components/My/DeleteButton';
+import useConfirmDeleteQuestionsModal from '@/hooks/useConfirmDeleteQuestionsModal';
 import useQuestionsLocalStorage from '@/hooks/useQuestionsLocalStorage';
-import { categoryKeys, CategoryKeys } from '@/constants/categories';
-import { ReactComponent as Blue } from '@/assets/images/blue.svg';
-
-const categories = ['ALL', '셀프', '커플', '우정', '랜덤', '같이해요'] as const;
-type CategoryType = (typeof categories)[number];
-
-const categoryMap = {
-  ALL: 'all',
-  ...Object.fromEntries(
-    categories.slice(1).map((category, index) => [category, categoryKeys[index]]),
-  ),
-} as Record<CategoryType, 'all' | CategoryKeys>;
 
 export default function My() {
-  const [questions, setQuestions] = useQuestionsLocalStorage();
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
-  const [selectedCategory, setSelectedCategory] = useState<CategoryType>('ALL');
-  const [isOpen, setIsOpen] = useState(false);
-  const filteredQuestions =
-    selectedCategory === 'ALL'
-      ? questions
-      : questions.filter((question) => question.category === categoryMap[selectedCategory]);
-
-  const handleClickCategory = (category: CategoryType) => setSelectedCategory(category);
-
-  const handleToggleCheckbox = (questionId: number) => {
-    setSelectedIds((prev) => {
-      if (prev.includes(questionId)) {
-        prev = prev.filter((value) => value !== questionId);
-      } else {
-        prev = [...prev, questionId];
-      }
-      return prev;
-    });
-  };
-
-  const handleDelete = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setQuestions((prev) => prev.filter((question) => !selectedIds.includes(question.id)));
-    setSelectedIds([]);
-    handleCloseModal();
-  };
-
-  const handleOpenModal = useCallback(() => {
-    setIsOpen(true);
-  }, []);
-
-  const handleCloseModal = useCallback(() => {
-    setIsOpen(false);
-  }, []);
+  const [selectedCategory, setSelectedCategory] = useState<DisplayedCategory>('ALL');
+  const [questions, setQuestions] = useQuestionsLocalStorage();
+  const [renderConfirmDeleteQuestionsModal, handleOpenModal] = useConfirmDeleteQuestionsModal({
+    selectedIds,
+    setSelectedIds,
+    setQuestions,
+  });
 
   return (
     <>
       <main className="flex h-full w-full flex-col bg-dark pt-46">
         <Navbar isMy={true} className="fixed top-0 z-10 w-full max-w-mobile bg-white px-default" />
         <div className="bg-dark px-default pb-[12.2rem]">
-          <section aria-labelledby="category" className="pb-38 pt-30">
-            <h2 id="category" className="a11y-hidden">
-              카테고리
-            </h2>
-            <div className="flex flex-wrap gap-8">
-              {categories.map((category) => (
-                <button
-                  key={category}
-                  type="button"
-                  className={`font-14 rounded-[1rem] px-18 py-10 font-semibold ${
-                    category === selectedCategory ? 'bg-cyan text-dark' : 'bg-primary text-tertiary'
-                  }`}
-                  onClick={() => handleClickCategory(category)}
-                >
-                  {category}
-                </button>
-              ))}
-            </div>
-          </section>
-          <section aria-labelledby="list">
-            <h2 id="list" className="a11y-hidden">
-              저장한 질문 리스트
-            </h2>
-
-            {filteredQuestions.length > 0 && (
-              <div className="font-14 mb-10 font-semibold text-white">
-                {filteredQuestions.length}개의 질문
-              </div>
-            )}
-
-            {filteredQuestions.length === 0 ? (
-              <div className="mt-112 flex flex-col items-center">
-                <Blue aria-hidden={true} />
-                <div className="font-18 mt-10 font-normal text-tertiary">
-                  아직 저장한 질문이 없어요!
-                </div>
-              </div>
-            ) : null}
-            <ul className="flex h-full flex-col gap-8">
-              {filteredQuestions.map((question) => (
-                <QuestionItem
-                  key={question.id}
-                  question={question}
-                  handleCheck={() => handleToggleCheckbox(question.id)}
-                  isChecked={selectedIds.includes(question.id)}
-                />
-              ))}
-            </ul>
-          </section>
+          <CategoriesSection
+            selectedCategory={selectedCategory}
+            setSelectedCategory={setSelectedCategory}
+          />
+          <SavedQuestionsSection
+            questions={questions}
+            selectedCategory={selectedCategory}
+            selectedIds={selectedIds}
+            setSelectedIds={setSelectedIds}
+          />
         </div>
         <div className="fixed bottom-0 w-full max-w-mobile bg-white px-default py-24">
-          <Button
-            className="font-18 w-full max-w-[calc(var(--max-width)-2*var(--padding))] py-[1.9rem] font-semibold"
-            disabled={selectedIds.length === 0}
-            onClick={handleOpenModal}
-          >
-            {selectedIds.length === 0 ? '삭제하기' : `${selectedIds.length}개의 질문 삭제하기`}
-          </Button>
+          <DeleteButton selectedIds={selectedIds} onClick={handleOpenModal} />
         </div>
       </main>
-      <ConfirmDeleteModal
-        isOpen={isOpen}
-        onClose={handleCloseModal}
-        onDelete={handleDelete}
-        className="p-40"
-      />
+      {renderConfirmDeleteQuestionsModal()}
     </>
   );
 }


### PR DESCRIPTION
## 작업 내용
- CategoriesSection 컴포넌트 분리
- SavedquestionsSection 컴포넌트 분리
- DeleteButton 컴포넌트 분리
- 표시되는 카테고리들 상수로 분리
- Modal 공통 컴포넌트의 필요없는 optional props 제거
- ConfirmDeleteModal에 접근성을 위한 aria-label 추가
- 로직 분리를 위한 useConfirmDeleteQuestionsModal 커스텀 훅 추가

closes: #89
## 주의 사항
